### PR TITLE
use a real local server address instead of predefined

### DIFF
--- a/webapp/webapp_flow.go
+++ b/webapp/webapp_flow.go
@@ -24,7 +24,6 @@ type Flow struct {
 	server      *localServer
 	clientID    string
 	state       string
-	grantType   string
 	redirectURI string
 }
 

--- a/webapp/webapp_flow.go
+++ b/webapp/webapp_flow.go
@@ -64,7 +64,7 @@ func (flow *Flow) BrowserURL(baseURL string, params BrowserParams) (string, erro
 	ru.Host = fmt.Sprintf("%s:%d", ru.Hostname(), flow.server.Port())
 	flow.server.CallbackPath = ru.Path
 	flow.clientID = params.ClientID
-	flow.redirectURI = params.RedirectURI
+	flow.redirectURI = ru.String()
 
 	q := url.Values{}
 	q.Set("client_id", params.ClientID)

--- a/webapp/webapp_flow_test.go
+++ b/webapp/webapp_flow_test.go
@@ -144,7 +144,7 @@ func TestFlow_AccessToken(t *testing.T) {
 	if apiPost.url != "https://github.com/access_token" {
 		t.Errorf("HTTP POST to %q", apiPost.url)
 	}
-	if params := apiPost.params.Encode(); params != "client_id=CLIENT-ID&client_secret=OAUTH-SEKRIT&code=ABC-123&state=xy%2Fz" {
+	if params := apiPost.params.Encode(); params != "client_id=CLIENT-ID&client_secret=OAUTH-SEKRIT&code=ABC-123&grant_type=authorization_code&redirect_uri=&state=xy%2Fz" {
 		t.Errorf("HTTP POST params: %v", params)
 	}
 


### PR DESCRIPTION
There are two stages to authentication.
 - https://bitbucket.org/site/oauth2/authorize
 - https://bitbucket.org/site/oauth2/access_token
 
They both take a redirect_uri in the POST body but must be identical for both calls. 